### PR TITLE
Hide default factory constants of NumberTypeAdapter and ObjectTypeAdapter

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -228,7 +228,7 @@ public final class Gson {
 
     // built-in type adapters that cannot be overridden
     factories.add(TypeAdapters.JSON_ELEMENT_FACTORY);
-    factories.add(objectAdapterFactory(objectToNumberStrategy));
+    factories.add(ObjectTypeAdapter.getFactory(objectToNumberStrategy));
 
     // the excluder must precede all adapters that handle user-defined types
     factories.add(excluder);
@@ -248,7 +248,7 @@ public final class Gson {
             doubleAdapter(serializeSpecialFloatingPointValues)));
     factories.add(TypeAdapters.newFactory(float.class, Float.class,
             floatAdapter(serializeSpecialFloatingPointValues)));
-    factories.add(numberAdapterFactory(numberToNumberStrategy));
+    factories.add(NumberTypeAdapter.getFactory(numberToNumberStrategy));
     factories.add(TypeAdapters.ATOMIC_INTEGER_FACTORY);
     factories.add(TypeAdapters.ATOMIC_BOOLEAN_FACTORY);
     factories.add(TypeAdapters.newFactory(AtomicLong.class, atomicLongAdapter(longAdapter)));
@@ -366,20 +366,6 @@ public final class Gson {
           + " is not a valid double value as per JSON specification. To override this"
           + " behavior, use GsonBuilder.serializeSpecialFloatingPointValues() method.");
     }
-  }
-
-  private static TypeAdapterFactory objectAdapterFactory(ToNumberStrategy objectToNumberStrategy) {
-    if (objectToNumberStrategy == ToNumberPolicy.DOUBLE) {
-      return ObjectTypeAdapter.FACTORY;
-    }
-    return ObjectTypeAdapter.newFactory(objectToNumberStrategy);
-  }
-
-  private static TypeAdapterFactory numberAdapterFactory(final ToNumberStrategy numberToNumberStrategy) {
-    if (numberToNumberStrategy == ToNumberPolicy.LAZILY_PARSED_NUMBER) {
-      return NumberTypeAdapter.FACTORY;
-    }
-    return NumberTypeAdapter.newFactory(numberToNumberStrategy);
   }
 
   private static TypeAdapter<Number> longAdapter(LongSerializationPolicy longSerializationPolicy) {

--- a/gson/src/main/java/com/google/gson/internal/bind/NumberTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/NumberTypeAdapter.java
@@ -36,7 +36,7 @@ public final class NumberTypeAdapter extends TypeAdapter<Number> {
   /**
    * Gson default factory using {@link ToNumberPolicy#LAZILY_PARSED_NUMBER}.
    */
-  public static final TypeAdapterFactory FACTORY = newFactory(ToNumberPolicy.LAZILY_PARSED_NUMBER);
+  private static final TypeAdapterFactory LAZILY_PARSED_NUMBER_FACTORY = newFactory(ToNumberPolicy.LAZILY_PARSED_NUMBER);
 
   private final ToNumberStrategy toNumberStrategy;
 
@@ -44,16 +44,22 @@ public final class NumberTypeAdapter extends TypeAdapter<Number> {
     this.toNumberStrategy = toNumberStrategy;
   }
 
-  public static TypeAdapterFactory newFactory(final ToNumberStrategy toNumberStrategy) {
+  private static TypeAdapterFactory newFactory(ToNumberStrategy toNumberStrategy) {
+    final NumberTypeAdapter adapter = new NumberTypeAdapter(toNumberStrategy);
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
       @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        if (type.getRawType() == Number.class) {
-          return (TypeAdapter<T>) new NumberTypeAdapter(toNumberStrategy);
-        }
-        return null;
+        return type.getRawType() == Number.class ? (TypeAdapter<T>) adapter : null;
       }
     };
+  }
+
+  public static TypeAdapterFactory getFactory(ToNumberStrategy toNumberStrategy) {
+    if (toNumberStrategy == ToNumberPolicy.LAZILY_PARSED_NUMBER) {
+      return LAZILY_PARSED_NUMBER_FACTORY;
+    } else {
+      return newFactory(toNumberStrategy);
+    }
   }
 
   @Override public Number read(JsonReader in) throws IOException {

--- a/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/ObjectTypeAdapter.java
@@ -40,7 +40,7 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
   /**
    * Gson default factory using {@link ToNumberPolicy#DOUBLE}.
    */
-  public static final TypeAdapterFactory FACTORY = newFactory(ToNumberPolicy.DOUBLE);
+  private static final TypeAdapterFactory DOUBLE_FACTORY = newFactory(ToNumberPolicy.DOUBLE);
 
   private final Gson gson;
   private final ToNumberStrategy toNumberStrategy;
@@ -50,7 +50,7 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
     this.toNumberStrategy = toNumberStrategy;
   }
 
-  public static TypeAdapterFactory newFactory(final ToNumberStrategy toNumberStrategy) {
+  private static TypeAdapterFactory newFactory(final ToNumberStrategy toNumberStrategy) {
     return new TypeAdapterFactory() {
       @SuppressWarnings("unchecked")
       @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
@@ -60,6 +60,14 @@ public final class ObjectTypeAdapter extends TypeAdapter<Object> {
         return null;
       }
     };
+  }
+
+  public static TypeAdapterFactory getFactory(ToNumberStrategy toNumberStrategy) {
+    if (toNumberStrategy == ToNumberPolicy.DOUBLE) {
+      return DOUBLE_FACTORY;
+    } else {
+      return newFactory(toNumberStrategy);
+    }
   }
 
   @Override public Object read(JsonReader in) throws IOException {


### PR DESCRIPTION
Sorry for this extra pull request, I missed these changes in the last one.

Changes by this pull request:
- Hide default factory constants to encapsulate the logic and do not expose to `Gson.class` that these constants exist.
- Additionally refactored factory created by NumberTypeAdapter to only create TypeAdapter once (previously it would create a new one for every `TypeAdapterFactory.create` call) and then have factory reuse that adapter for better performance.